### PR TITLE
disable clicks and set cursor to default

### DIFF
--- a/lesson2-focus/01-basic-form/main.css
+++ b/lesson2-focus/01-basic-form/main.css
@@ -23,6 +23,8 @@ html, body {
   height: 100%;
   display: flex;
   flex-direction: column;
+  pointer-events: none;
+  cursor: default;
 }
 
 .container {


### PR DESCRIPTION
Check box and SelectBox were clickable (at least on my Firefox 50), I edited `.wrapper `class by adding these properties
```css
.wrapper {
  ...
  pointer-events: none;
  cursor: default;
}
```